### PR TITLE
Add Boron support and update AssetTrackerRK lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,23 @@ attennas to the data-link bus all but the primary antenna should have a diode on
 the tx line. If you don't plan on impersonating the remote starter you only need
 one diode.
 
-[Level Shifter](https://www.sparkfun.com/products/12009) Particle MCUs (photon, electron)
+[Level Shifter](https://www.sparkfun.com/products/12009) Particle MCUs (Boron, Photon, Electron...)
 use 3.3v logic levels. While the Fortin remote starter uses a 5v logic level. Thus if
 you don't want to fry your Particle you will need to convert the 5v signal from the
 remote starter to a 3.3v signal and vice-versa.
 
-[Electron](https://store.particle.io/collections/cellular/products/electron-3g-americas) or
-[Photon](https://store.particle.io/collections/wifi/products/photon) The electron has more
-uarts than the photon, as such it is capable of monitoring the data-link connection in
+[Electron](https://store.particle.io/collections/cellular/products/electron-3g-americas) (discontinued) or
+[Photon](https://store.particle.io/collections/wifi/products/photon) (discontinued) or
+[Boron](https://store.particle.io/products/boron-lte-cat-m1-noram-with-ethersim-4th-gen): The Electron has more
+uarts than the Boron or Photon, as such it is capable of monitoring the data-link connection in
 both directions.
 
-[5v regulator](https://www.sparkfun.com/products/107) If you are using an electron you
+[5v regulator](https://www.sparkfun.com/products/107) If you are using an Electron, you
 will need some way to provide a 5v reference to your level shifter. DO NOT use this to
-power the photon from the data-link 12v-14v source. If you need to power a photon you
+power the Boron or Photon from the data-link 12v-14v source. If you need to power the Boron or Photon, you
 should use a buck down DC->DC power supply, or other USB power source.
 
-[Particle Asset Tracker](https://store.particle.io/products/asset-tracker-v2-components)
+[Particle Asset Tracker](https://store.particle.io/products/asset-tracker-v2-components) (discontinued)
 If you want to add a gps/accelerometer to your set up.
 
 ## How to connect to Fortin Evo-One

--- a/project.properties
+++ b/project.properties
@@ -1,2 +1,2 @@
 name=openremotestart
-dependencies.AssetTrackerRK=0.2.3
+dependencies.AssetTrackerRK=0.4.2

--- a/src/openremotestart.ino
+++ b/src/openremotestart.ino
@@ -76,6 +76,14 @@ SYSTEM_THREAD(ENABLED);
     #define StarterUart Serial5
     #define ORS_MS_BETWEEN_STATUS_PUBLISH 600000
     #define ORS_ASSET_TRACKER
+
+#elif (PLATFORM_ID == 13) // BORON
+    #ifdef ORS_PREFER_STARTER_UART
+        #define StarterUart Serial1
+    #else
+        #define RemoteUart Serial1
+    #endif
+    #define ORS_MS_BETWEEN_STATUS_PUBLISH 600000
 #endif
 
 #ifdef ORS_ASSET_TRACKER
@@ -222,6 +230,9 @@ float m_last_alt = 0;
 // The current number of satellites being tracked
 int m_satellite_count = 0;
 
+// Is the gps currently turned on?
+bool m_is_gps_on;
+
 #ifdef ORS_ASSET_TRACKER
     AssetTracker tracker = AssetTracker();
 
@@ -231,9 +242,6 @@ int m_satellite_count = 0;
     // When the gps turned on. This is used to
     // determine if it is time to shut the gps off
     unsigned long m_gps_on_time;
-
-    // Is the gps currently turned on?
-    bool m_is_gps_on;
 
     unsigned long m_last_gps_update = 0;
     unsigned long m_last_gps_log_time = 0;


### PR DESCRIPTION
Added support for the Particle Boron (BRN404X) as well as updated the AssetTrackerRK library version. An additional change I made was moving the declaration for `m_is_gps_on` to a more global scope to avoid an Intellisense warning.